### PR TITLE
updated the Verify installation via python interpreter section to fix…

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ from data_fixr import (
     correlation_report,
     remove_duplicates,
     detect_anomalies,
-    fill_missing_values
+    missing_values
 )
 ```
 


### PR DESCRIPTION
@nourshawk @apoorva43 @zainnofal 

I updated the "Verify installation via Python interpreter" section to fix an error. It was currently throwing an error because in our repo, it is "missing_values" and not "fill_missing_values".

